### PR TITLE
Fix wrong context in CalendarManager

### DIFF
--- a/kotlin-agendacalendarview/src/main/java/com/ognev/kotlin/agendacalendarview/CalendarManager.kt
+++ b/kotlin-agendacalendarview/src/main/java/com/ognev/kotlin/agendacalendarview/CalendarManager.kt
@@ -245,7 +245,7 @@ class CalendarManager
 
         fun getInstance(context: Context): CalendarManager {
             if (instance == null) {
-                instance = CalendarManager(context)
+                instance = CalendarManager(context.applicationContext)
             }
             return instance as CalendarManager
         }

--- a/kotlin-agendacalendarview/src/main/java/com/ognev/kotlin/agendacalendarview/builder/CalendarContentManager.kt
+++ b/kotlin-agendacalendarview/src/main/java/com/ognev/kotlin/agendacalendarview/builder/CalendarContentManager.kt
@@ -1,5 +1,6 @@
 package com.ognev.kotlin.agendacalendarview.builder
 
+import android.app.Application
 import com.ognev.kotlin.agendacalendarview.AgendaCalendarView
 import com.ognev.kotlin.agendacalendarview.CalendarManager
 import com.ognev.kotlin.agendacalendarview.CalendarController


### PR DESCRIPTION
Holding context from view in static fields was cause of leak